### PR TITLE
feat: preserve query strings when using website configuration redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ module "static_site" {
 | <a name="module_authorizer"></a> [authorizer](#module\_authorizer) | github.com/chatloop/terraform-aws-cloudfront-auth | 695c3eb440a90e2441a006f9d091e6f73218fb0d |
 | <a name="module_cloudfront"></a> [cloudfront](#module\_cloudfront) | github.com/terraform-aws-modules/terraform-aws-cloudfront | a0f0506106a4c8815c1c32596e327763acbef2c2 |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | github.com/terraform-aws-modules/terraform-aws-s3-bucket | 8a0b697adfbc673e6135c70246cff7f8052ad95a |
+| <a name="module_website_configuration"></a> [website\_configuration](#module\_website\_configuration) | github.com/terraform-aws-modules/terraform-aws-lambda | 1d122404c2a3834ce39a7c5a319a3e754d5b0c29 |
 
 ## Resources
 

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -9,4 +9,8 @@ module "static_site" {
   domain_name          = var.domain_name
   name                 = "terraform-aws-static-site"
   route53_zone_name    = var.route53_zone_name
+
+  website_configuration = {
+    index_document = "index.html"
+  }
 }

--- a/examples/minimal/provider.tf
+++ b/examples/minimal/provider.tf
@@ -1,8 +1,12 @@
 provider "aws" {
   region = "eu-west-2"
+
+  allowed_account_ids = var.allowed_account_ids
 }
 
 provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
+
+  allowed_account_ids = var.allowed_account_ids
 }

--- a/examples/minimal/variables.tf
+++ b/examples/minimal/variables.tf
@@ -2,6 +2,10 @@ variable "acm_certificate_name" {
   type = string
 }
 
+variable "allowed_account_ids" {
+  type = list(string)
+}
+
 variable "domain_name" {
   type = string
 }

--- a/src/website-configuration/index.js
+++ b/src/website-configuration/index.js
@@ -1,0 +1,10 @@
+exports.handler = (event, context, callback) => {
+  const request = event.Records[0].cf.request;
+  const uri = request.uri;
+
+  if (!uri.includes('.') && !uri.endsWith('/')) {
+    request.uri += '/';
+  }
+
+  callback(null, request);
+}


### PR DESCRIPTION
Also prevents S3 from redirecting directory paths, and instead just loads them